### PR TITLE
fix: wrong quoting in aiohttp install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ You can enable this by installing `aiohttp`:
 
 ```sh
 # install from PyPI
-pip install '--pre zeroentropy[aiohttp]'
+pip install --pre 'zeroentropy[aiohttp]'
 ```
 
 Then you can enable it by instantiating the client with `http_client=DefaultAioHttpClient()`:


### PR DESCRIPTION
## Summary
The aiohttp installation command in the README has the quotes in the wrong place: `pip install '--pre zeroentropy[aiohttp]'` wraps `--pre` inside the quotes, so pip interprets the entire string as a single package name instead of a flag followed by the package. The correct command is `pip install --pre 'zeroentropy[aiohttp]'`.

## How to reproduce
Copy the command from the README "With aiohttp" section and run it:
```sh
pip install '--pre zeroentropy[aiohttp]'
```
pip will error with something like `ERROR: Could not find a version that satisfies the requirement --pre zeroentropy[aiohttp]`.

## Test plan
Run the corrected command `pip install --pre 'zeroentropy[aiohttp]'` and confirm pip recognizes `--pre` as a flag and installs the `zeroentropy[aiohttp]` extra.